### PR TITLE
Major electron-builder patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "files": [
       "**/*",
       "build/**/*",
+      "assets/**/*",
+      "!dist/**/*",
+      "!src/**/*",
       "node_modules/**/*"
     ]
   },


### PR DESCRIPTION
- Added ignore for 'dist' and 'src' directories during the build phase.

> It's extremely important to ignore the distribution directory to prevent consecutive builds from including the prior. I.e, exponentially increasing file size per build!